### PR TITLE
修复mongodb3.0关闭连接时报错o.destroy is not a function

### DIFF
--- a/index.js
+++ b/index.js
@@ -12,11 +12,11 @@ module.exports = (opt, maxsize, timeout) => {
 
     var create = opt.create;
     var destroy = opt.destroy || ((o) => {
-        if (o.close)
+        if (util.isFunction(o.close))
             o.close();
-        if (o.destroy)
+        if (util.isFunction(o.destroy))
             o.destroy();
-        if (o.dispose)
+        if (util.isFunction(o.dispose))
             o.dispose();
     });
 

--- a/test.js
+++ b/test.js
@@ -3,7 +3,7 @@ test.setup();
 
 var coroutine = require("coroutine");
 
-var Pool = require(".");
+var Pool = require("./index");
 
 describe("pool", () => {
     it("run", () => {
@@ -172,6 +172,26 @@ describe("pool", () => {
         assert.isFalse(called);
         coroutine.sleep(10);
         assert.isTrue(called);
+    });
+
+
+    it("default destroy function, but destroy is not a function, mongodb3.0 case", ()=>{
+        var cnt = 0;
+        var p = Pool({
+            create: () => {
+                return {
+                    destroy: ++cnt
+                    }
+                }
+            })
+
+        assert.throws(() => {
+            p((v) => {
+                throw "error";
+            });
+        });
+
+        assert.equal(cnt, 1);
     });
 
     it("default dispose function", () => {


### PR DESCRIPTION
1.修复在工程目录下 require(".")会报错的问题
2.修复mongodb3.0关闭连接时报错o.destroy is not a function
3.添加当连接关闭属性不是一个函数时的测试用例